### PR TITLE
refactor to template-only components

### DIFF
--- a/addon/components/bs-form/element/control/power-select-multiple.js
+++ b/addon/components/bs-form/element/control/power-select-multiple.js
@@ -1,3 +1,0 @@
-import Control from 'ember-bootstrap/components/bs-form/element/control';
-
-export default class PowerSelectControl extends Control {}

--- a/addon/components/bs-form/element/control/power-select.js
+++ b/addon/components/bs-form/element/control/power-select.js
@@ -1,3 +1,0 @@
-import Control from 'ember-bootstrap/components/bs-form/element/control';
-
-export default class PowerSelectControl extends Control {}


### PR DESCRIPTION
Having a JavaScript class, which extends from `ember-bootstrap/bs-form/element/control`, does not seem to be necessary as all. Components does not seem using the backing JavaScript class at all. The components do not use `this` in their templates.

Closes #348 