### PR TITLE
Adds support for searchFieldPosition (introduced in ember-power-select v8.6.2)

### DIFF
--- a/addon/components/bs-form/element/control/power-select.hbs
+++ b/addon/components/bs-form/element/control/power-select.hbs
@@ -43,6 +43,7 @@
     @scrollTo={{@scrollTo}}
     @search={{@search}}
     @searchEnabled={{@searchEnabled}}
+    @searchFieldPosition={{@searchFieldPosition}}
     @searchField={{if (has-block) @searchField (if @searchField @searchField @optionLabelPath)}}
     @searchMessage={{@searchMessage}}
     @searchPlaceholder={{@searchPlaceholder}}


### PR DESCRIPTION
Field searchFieldPosition was added to ember-power-select in https://github.com/cibernox/ember-power-select/pull/1864, support was missing until now.