### PR TITLE
run blueprint tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,22 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run Tests
         run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+
+  blueprint:
+    name: "Blueprint"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: pnpm
+      - name: Install Dependencies
+        run: pnpm install --no-lockfile
+      - name: Run Tests
+        run: pnpm test:blueprint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
   blueprint:
     name: "Blueprint"
     runs-on: ubuntu-latest
+    needs: "test"
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
Tests for the blueprints were added in #393 but we missed updating the CI pipeline to actually run them.