### PR TITLE
drop support for Ember classic (pre Octane)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
           - ember-release
           - ember-beta
           - ember-canary
-          - ember-classic
           - ember-power-select-v6
           - ember-power-select-v7
           # - embroider-safe

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -57,25 +57,6 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-classic',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'application-template-wrapper': true,
-            'default-async-observers': false,
-            'template-only-glimmer-components': false,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            'ember-cli': '~3.28.0',
-            'ember-source': '~3.28.0',
-          },
-          ember: {
-            edition: 'classic',
-          },
-        },
-      },
-      {
         name: 'ember-power-select-v6',
         npm: {
           devDependencies: {


### PR DESCRIPTION
This drops support for Ember classic edition. Ember 3.28 is still supported.

Maintenance costs of supporting that old edition aren't worth it anymore. We can assume that everyone upgraded to Octane at this point in time. Even though if they may still be at Ember 3.28.